### PR TITLE
Transform ReflectionUtils as a top level function collection

### DIFF
--- a/src/main/kotlin/org/taktik/couchdb/support/SimpleViewGenerator.kt
+++ b/src/main/kotlin/org/taktik/couchdb/support/SimpleViewGenerator.kt
@@ -22,7 +22,7 @@ import org.taktik.couchdb.annotation.View
 import org.taktik.couchdb.annotation.Views
 import org.taktik.couchdb.util.Exceptions
 import org.taktik.couchdb.util.Predicate
-import org.taktik.couchdb.util.ReflectionUtils
+import org.taktik.couchdb.util.eachAnnotation
 import java.io.FileNotFoundException
 import java.util.HashMap
 
@@ -42,7 +42,7 @@ class SimpleViewGenerator {
     }
 
     private fun createDeclaredViews(views: MutableMap<String, org.taktik.couchdb.entity.View>, klass: Class<*>) {
-        ReflectionUtils.eachAnnotation(klass, Views::class.java, object : Predicate<Views> {
+        eachAnnotation(klass, Views::class.java, object : Predicate<Views> {
             override fun apply(input: Views): Boolean {
                 for (v in input.value) {
                     addView(views, v, klass)
@@ -51,7 +51,7 @@ class SimpleViewGenerator {
             }
         })
 
-        ReflectionUtils.eachAnnotation(klass, View::class.java, object : Predicate<View> {
+        eachAnnotation(klass, View::class.java, object : Predicate<View> {
             override fun apply(input: View): Boolean {
                 addView(views, input, klass)
                 return true

--- a/src/main/kotlin/org/taktik/couchdb/support/StdDesignDocumentFactory.kt
+++ b/src/main/kotlin/org/taktik/couchdb/support/StdDesignDocumentFactory.kt
@@ -28,7 +28,7 @@ import org.taktik.couchdb.entity.DesignDocument
 import org.taktik.couchdb.util.Assert
 import org.taktik.couchdb.util.Exceptions
 import org.taktik.couchdb.util.Predicate
-import org.taktik.couchdb.util.ReflectionUtils
+import org.taktik.couchdb.util.eachAnnotation
 import java.io.FileNotFoundException
 
 /**
@@ -58,7 +58,7 @@ class StdDesignDocumentFactory {
     private fun createFilterFunctions(metaDataClass: Class<*>): Map<String, String> {
         val shows: MutableMap<String, String> = HashMap()
 
-        ReflectionUtils.eachAnnotation(metaDataClass, Filter::class.java, object : Predicate<Filter> {
+        eachAnnotation(metaDataClass, Filter::class.java, object : Predicate<Filter> {
             override fun apply(input: Filter): Boolean {
                 shows[input.name] = resolveFilterFunction(input, metaDataClass)
                 return true
@@ -66,7 +66,7 @@ class StdDesignDocumentFactory {
         })
 
 
-        ReflectionUtils.eachAnnotation(metaDataClass, Filters::class.java, object : Predicate<Filters> {
+        eachAnnotation(metaDataClass, Filters::class.java, object : Predicate<Filters> {
             override fun apply(input: Filters): Boolean {
                 for (sf in input.value) {
                     shows[sf.name] = resolveFilterFunction(sf, metaDataClass)
@@ -81,14 +81,14 @@ class StdDesignDocumentFactory {
     private fun createUpdateHandlerFunctions(metaDataClass: Class<*>): Map<String, String> {
         val updateHandlers: MutableMap<String, String> = HashMap()
 
-        ReflectionUtils.eachAnnotation(metaDataClass, UpdateHandler::class.java, object : Predicate<UpdateHandler> {
+        eachAnnotation(metaDataClass, UpdateHandler::class.java, object : Predicate<UpdateHandler> {
             override fun apply(input: UpdateHandler): Boolean {
                 updateHandlers[input.name] = resolveUpdateHandlerFunction(input, metaDataClass)
                 return true
             }
         })
 
-        ReflectionUtils.eachAnnotation(metaDataClass, UpdateHandlers::class.java, object : Predicate<UpdateHandlers> {
+        eachAnnotation(metaDataClass, UpdateHandlers::class.java, object : Predicate<UpdateHandlers> {
             override fun apply(input: UpdateHandlers): Boolean {
                 for (sf in input.value) {
                     updateHandlers[sf.name] = resolveUpdateHandlerFunction(sf, metaDataClass)
@@ -103,14 +103,14 @@ class StdDesignDocumentFactory {
     private fun createShowFunctions(metaDataClass: Class<*>): Map<String, String> {
         val shows: MutableMap<String, String> = HashMap()
 
-        ReflectionUtils.eachAnnotation(metaDataClass, ShowFunction::class.java, object : Predicate<ShowFunction> {
+        eachAnnotation(metaDataClass, ShowFunction::class.java, object : Predicate<ShowFunction> {
             override fun apply(input: ShowFunction): Boolean {
                 shows[input.name] = resolveShowFunction(input, metaDataClass)
                 return true
             }
         })
 
-        ReflectionUtils.eachAnnotation(metaDataClass, Shows::class.java, object : Predicate<Shows> {
+        eachAnnotation(metaDataClass, Shows::class.java, object : Predicate<Shows> {
             override fun apply(input: Shows): Boolean {
                 for (sf in input.value) {
                     shows[sf.name] = resolveShowFunction(sf, metaDataClass)
@@ -125,14 +125,14 @@ class StdDesignDocumentFactory {
     private fun createListFunctions(metaDataClass: Class<*>): Map<String, String> {
         val lists: MutableMap<String, String> = HashMap()
 
-        ReflectionUtils.eachAnnotation(metaDataClass, ListFunction::class.java, object : Predicate<ListFunction> {
+        eachAnnotation(metaDataClass, ListFunction::class.java, object : Predicate<ListFunction> {
             override fun apply(input: ListFunction): Boolean {
                 lists[input.name] = resolveListFunction(input, metaDataClass)
                 return true
             }
         })
 
-        ReflectionUtils.eachAnnotation(metaDataClass, Lists::class.java, object : Predicate<Lists> {
+        eachAnnotation(metaDataClass, Lists::class.java, object : Predicate<Lists> {
             override fun apply(input: Lists): Boolean {
                 for (lf in input.value) {
                     lists[lf.name] = resolveListFunction(lf, metaDataClass)

--- a/src/main/kotlin/org/taktik/couchdb/util/ReflectionUtils.kt
+++ b/src/main/kotlin/org/taktik/couchdb/util/ReflectionUtils.kt
@@ -21,88 +21,81 @@ import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 
-class ReflectionUtils {
+fun eachField(clazz: Class<*>, p: Predicate<Field>): Collection<Field> {
+    val result = mutableListOf<Field>()
 
-    companion object {
-
-        fun eachField(clazz: Class<*>, p: Predicate<Field>): Collection<Field> {
-            val result = mutableListOf<Field>()
-
-            clazz.declaredFields.forEach {
-                if (p.apply(it)) {
-                    result.add(it)
-                }
-            }
-
-            if (clazz.superclass != null) {
-                result.addAll(eachField(clazz.superclass, p))
-            }
-
-            return result
-        }
-
-        fun eachMethod(clazz: Class<*>, p: Predicate<Method>): Collection<Method> {
-            val result = mutableListOf<Method>()
-
-            clazz.declaredMethods.forEach {
-                if (p.apply(it)) {
-                    result.add(it)
-                }
-            }
-
-            if (clazz.superclass != null) {
-                result.addAll(eachMethod(clazz.superclass, p))
-            }
-
-            return result
-        }
-
-        fun <T : Annotation> eachAnnotation(
-                clazz: Class<*>,
-                annotationClass: Class<T>, p: Predicate<T>,
-        ) {
-
-            var a = clazz.getAnnotation(annotationClass)
-
-            if (a != null) {
-                p.apply(a)
-            }
-
-            clazz.declaredMethods.forEach {
-                a = it.getAnnotation(annotationClass)
-
-                if (a != null) {
-                    p.apply(a)
-                }
-            }
-
-            if (clazz.superclass != null) {
-                eachAnnotation(clazz.superclass, annotationClass, p)
-            }
-        }
-
-        /**
-         * Ignores case when comparing method names
-         *
-         * @param clazz
-         * @param name
-         * @return
-         */
-        fun findMethod(clazz: Class<*>, name: String): Method? {
-
-            clazz.declaredMethods.forEach {
-                if (it.name.equals(name, ignoreCase = true)) {
-                    return it
-                }
-            }
-
-            return if (clazz.superclass != null) {
-                findMethod(clazz.superclass, name)
-            } else null
-        }
-
-        fun hasAnnotation(e: AnnotatedElement, annotationClass: Class<out Annotation>): Boolean {
-            return e.getAnnotation(annotationClass) != null
+    clazz.declaredFields.forEach {
+        if (p.apply(it)) {
+            result.add(it)
         }
     }
+
+    if (clazz.superclass != null) {
+        result.addAll(eachField(clazz.superclass, p))
+    }
+
+    return result
 }
+
+fun eachMethod(clazz: Class<*>, p: Predicate<Method>): Collection<Method> {
+    val result = mutableListOf<Method>()
+
+    clazz.declaredMethods.forEach {
+        if (p.apply(it)) {
+            result.add(it)
+        }
+    }
+
+    if (clazz.superclass != null) {
+        result.addAll(eachMethod(clazz.superclass, p))
+    }
+
+    return result
+}
+
+fun <T : Annotation> eachAnnotation(
+        clazz: Class<*>,
+        annotationClass: Class<T>, p: Predicate<T>,
+) {
+    var a = clazz.getAnnotation(annotationClass)
+
+    if (a != null) {
+        p.apply(a)
+    }
+
+    clazz.declaredMethods.forEach {
+        a = it.getAnnotation(annotationClass)
+
+        if (a != null) {
+            p.apply(a)
+        }
+    }
+
+    if (clazz.superclass != null) {
+        eachAnnotation(clazz.superclass, annotationClass, p)
+    }
+}
+
+/**
+ * Ignores case when comparing method names
+ *
+ * @param clazz
+ * @param name
+ * @return
+ */
+fun findMethod(clazz: Class<*>, name: String): Method? {
+    clazz.declaredMethods.forEach {
+        if (it.name.equals(name, ignoreCase = true)) {
+            return it
+        }
+    }
+
+    return if (clazz.superclass != null) {
+        findMethod(clazz.superclass, name)
+    } else null
+}
+
+fun hasAnnotation(e: AnnotatedElement, annotationClass: Class<out Annotation>): Boolean {
+    return e.getAnnotation(annotationClass) != null
+}
+


### PR DESCRIPTION
Instead of using a class with companion object method (equivalent to Java class with static methods) it is more Kotlin-like to promote these util function as top level function.