### PR TITLE
Update Jackson dependencies to 2.12.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,9 +78,9 @@ dependencies {
     api("com.github.pozo:mapstruct-kotlin:1.3.1.2")
     kapt("com.github.pozo:mapstruct-kotlin-processor:1.3.1.2")
 
-    implementation(group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.11.1")
-    implementation(group = "com.fasterxml.jackson.core", name = "jackson-databind", version = "2.11.1")
-    implementation(group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-smile", version = "2.11.1")
+    implementation(group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.12.0")
+    implementation(group = "com.fasterxml.jackson.core", name = "jackson-databind", version = "2.12.0")
+    implementation(group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-smile", version = "2.12.0")
     implementation(group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8")
     implementation(group = "org.jetbrains.kotlin", name = "kotlin-reflect")
     implementation(group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version = "1.4.2")


### PR DESCRIPTION
Update Jackson dependencies to 2.12.0.

This update allows to avoid Unresolved reference issues. 